### PR TITLE
Correcting path to repo name

### DIFF
--- a/example-1/class-customize.php
+++ b/example-1/class-customize.php
@@ -62,7 +62,7 @@ final class Example_1_Customize {
 	public function sections( $manager ) {
 
 		// Load custom sections.
-		require_once( trailingslashit( get_template_directory() ) . 'trt-customize-pro/example-1/section-pro.php' );
+		require_once( trailingslashit( get_template_directory() ) . 'trt-customizer-pro/example-1/section-pro.php' );
 
 		// Register custom section types.
 		$manager->register_section_type( 'Example_1_Customize_Section_Pro' );
@@ -90,9 +90,9 @@ final class Example_1_Customize {
 	 */
 	public function enqueue_control_scripts() {
 
-		wp_enqueue_script( 'example-1-customize-controls', trailingslashit( get_template_directory_uri() ) . 'trt-customize-pro/example-1/customize-controls.js', array( 'customize-controls' ) );
+		wp_enqueue_script( 'example-1-customize-controls', trailingslashit( get_template_directory_uri() ) . 'trt-customizer-pro/example-1/customize-controls.js', array( 'customize-controls' ) );
 
-		wp_enqueue_style( 'example-1-customize-controls', trailingslashit( get_template_directory_uri() ) . 'trt-customize-pro/example-1/customize-controls.css' );
+		wp_enqueue_style( 'example-1-customize-controls', trailingslashit( get_template_directory_uri() ) . 'trt-customizer-pro/example-1/customize-controls.css' );
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -6,18 +6,18 @@ The goal is to provide examples so that theme authors are not bypassing the core
 
 ## Testing
 
-To test the output, simply drop the `trt-customize-pro` folder into the root of your theme like so:
+To test the output, simply drop the `trt-customizer-pro` folder into the root of your theme like so:
 
 ```
 /themes
         /your-theme
-                /trt-customize-pro
+                /trt-customizer-pro
 ```
 
 Then, load an example with this code in your theme's `functions.php`:
 
 ```
-require_once( trailingslashit( get_template_directory() ) . 'trt-customize-pro/example-1/class-customize.php' );
+require_once( trailingslashit( get_template_directory() ) . 'trt-customizer-pro/example-1/class-customize.php' );
 ```
 
 ## Usage


### PR DESCRIPTION
I was just doing a clone and had copied the path from the readme which didn't match the repo.  Figured someone else might do the same at some point :P